### PR TITLE
Fix import to Redis

### DIFF
--- a/writer/redis.js
+++ b/writer/redis.js
@@ -20,7 +20,9 @@ async function insertOne(client, data) {
 	if (nk === 3 && data.hasOwnProperty('score') && data.hasOwnProperty('value')) {
 		client.zadd(data._key, data.score, data.value);
 	} else if (nk === 2 && data.hasOwnProperty('members')) {
-		client.sadd(data._key, data.members);
+		if (data.members.length > 0) {
+			client.sadd(data._key, data.members);
+		}
 	} else if (nk === 2 && data.hasOwnProperty('array')) {
 		client.lpush(data._key, data.array);
 	} else if (nk === 2 && data.hasOwnProperty('data') || data.hasOwnProperty('value')) {
@@ -32,7 +34,9 @@ async function insertOne(client, data) {
 				command.push(key, data[key]);
 			}
 		}
-		client.hmset(command);
+		if (command[1]) {
+			client.hmset(command);
+		}
 	}
 
 	if (expireAt) {


### PR DESCRIPTION
@BenLubar thanks for this tool!

This PR addresses a few issues with going from mongo -> redis.

Issue 1: 
```
ReplyError: ERR wrong number of arguments for 'hmset' command
```
Checking for a non-null second item in the `command` array fixes this issue. 

Issue 2: 
```
ReplyError: ERR wrong number of arguments for 'sadd' command
```
Similar to the first one, this is fixed by checking that `data.members` isn't empty. 